### PR TITLE
ログイン画面のエラーハンドリング実装

### DIFF
--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -29,6 +29,13 @@ export interface Logout {
   type: string;
 }
 
+const LOGIN_ERROR = 'LOGIN_ERROR';
+export interface LoginError {
+  type: string;
+  isError: boolean;
+  message: string;
+}
+
 export function increase(n: number): Increase {
   return {
     type: INCREASE,
@@ -62,5 +69,13 @@ export function loginAsync(username: string, password: string): LoginAsync {
 export function logout(): Logout {
   return {
     type: LOGOUT,
+  };
+}
+
+export function error(isError: boolean, message: string): LoginError {
+  return {
+    type: LOGIN_ERROR,
+    isError,
+    message,
   };
 }

--- a/src/api/AttendanceApi.ts
+++ b/src/api/AttendanceApi.ts
@@ -16,7 +16,7 @@ export function postLogin(name: string, password: string) {
     mode: 'cors',
   }).then(res => {
     if (!res.ok) {
-      res.json().then(data => {
+      return res.json().then(data => {
         throw new Error(data.message);
       });
     }

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -79,7 +79,9 @@ class Login extends React.Component<LoginProperties, LoginState> {
           </button>
         </div>
         {error.isError && (
-          <div className="siimple-form-field-helper">{error.message}</div>
+          <div className="siimple-form-field-helper siimple--color-red">
+            {error.message}
+          </div>
         )}
       </form>
     );

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -20,6 +20,20 @@ class Login extends React.Component<LoginProperties, LoginState> {
       name: '',
       password: '',
     };
+    this.handleLogin = this.handleLogin.bind(this);
+  }
+
+  handleLogin(
+    event: React.FormEvent<HTMLElement>,
+    name: string,
+    password: string,
+  ) {
+    const { login } = this.props;
+    if (name === '' || password === '') {
+      return;
+    }
+    login(name, password);
+    event.preventDefault();
   }
 
   render() {
@@ -27,11 +41,7 @@ class Login extends React.Component<LoginProperties, LoginState> {
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (
-      <form
-        className="siimple-form login-form"
-        autoComplete="off"
-        method="post"
-      >
+      <form className="siimple-form login-form">
         <div className="siimple-form-title">ログイン</div>
         <div className="siimple-form-field">
           <div className="siimple-form-field-label">ユーザー名</div>
@@ -58,8 +68,10 @@ class Login extends React.Component<LoginProperties, LoginState> {
         <div className="siimple-form-field">
           <button
             className="siimple-btn siimple-btn--blue"
-            type="button"
-            onClick={() => login(this.state.name, this.state.password)}
+            type="submit"
+            onClick={event =>
+              this.handleLogin(event, this.state.name, this.state.password)
+            }
           >
             ログイン
           </button>

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import Account from '../../models/Account';
+import Error from '../../models/Error';
 
 interface LoginProperties {
   login(id: string, password: string): void;
   account: Account;
+  error: Error;
 }
 
 interface LoginState {
@@ -37,7 +39,7 @@ class Login extends React.Component<LoginProperties, LoginState> {
   }
 
   render() {
-    const { login, account } = this.props;
+    const { login, account, error } = this.props;
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (
@@ -76,6 +78,9 @@ class Login extends React.Component<LoginProperties, LoginState> {
             ログイン
           </button>
         </div>
+        {error.isError && (
+          <div className="siimple-form-field-helper">{error.message}</div>
+        )}
       </form>
     );
   }

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -8,10 +8,12 @@ import Login from '../components/screens/Login';
 import { decrease, increase, loginAsync, logout } from '../action';
 import Navbar from '../components/Navbar';
 import Account from '../models/Account';
+import Error from '../models/Error';
 
 interface AppContainerProperties {
   number: number;
   account: Account;
+  error: Error;
   dispatch: any;
 }
 
@@ -45,7 +47,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
   }
 
   render() {
-    const { number, account } = this.props;
+    const { number, account, error } = this.props;
     return (
       <BrowserRouter basename="/">
         <div className="content">
@@ -53,7 +55,9 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
           <Switch>
             <Route
               path="/login"
-              render={() => <Login login={this.login} account={account} />}
+              render={() => (
+                <Login login={this.login} account={account} error={error} />
+              )}
             />
             <Route
               path="/home"
@@ -77,6 +81,7 @@ function mapStateToProps(state: any): object {
   return {
     number: state.number,
     account: state.account,
+    error: state.error,
   };
 }
 

--- a/src/models/Error.ts
+++ b/src/models/Error.ts
@@ -1,0 +1,4 @@
+export default interface Error {
+  isError: boolean;
+  message: string;
+}

--- a/src/reducer/index.ts
+++ b/src/reducer/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import Account from '../models/Account';
+import Error from '../models/Error';
 
 const initialState = 1;
 
@@ -46,7 +47,27 @@ function account(state = initialAccountState, action: any): Account {
   }
 }
 
+const initialErrorState: Error = {
+  isError: false,
+  message: '不明なエラー',
+};
+
+function error(state = initialErrorState, action: any): Error {
+  switch (action.type) {
+    case 'LOGIN_ERROR': {
+      return {
+        isError: action.isError,
+        message: action.message,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
 export const appReducer = combineReducers({
   number,
   account,
+  error,
 });

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -1,6 +1,6 @@
 import { all, call, put, takeEvery } from 'redux-saga/effects';
 
-import { login, LoginAsync } from '../action/';
+import { error as errorAction, login, LoginAsync } from '../action/';
 import { postLogin } from '../api/AttendanceApi';
 
 function* loginAsync(action: LoginAsync) {
@@ -9,9 +9,10 @@ function* loginAsync(action: LoginAsync) {
     const response = yield call(postLogin, name, password);
     // TODO: get administer authority by response
     yield put(login(response.user, true));
+    yield put(errorAction(false, ''));
   } catch (error) {
     // TODO: put action to error
-    yield console.error(error.message);
+    yield put(errorAction(true, error.message));
   }
 }
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,4 +1,5 @@
 @import "siimple";
+@import "siimple-colors/scss/siimple-colors";
 
 $baseColor: #ffffff;
 


### PR DESCRIPTION
## issue
- close #20 

## 概要
- ログインフォームに入力がないと入力を促すようにした（標準の設定、デザインなし）
- ログインがミスるとエラーを表示するようにした
  - エラーメッセージはAPIからのメッセージをそのまんま表示してます

## スクショ
|入力なし|ログインエラー|
|:-:|:-:|
|<img width="80%" alt="2018-05-24 17 24 27" src="https://user-images.githubusercontent.com/25450416/40473537-64d4e872-5f77-11e8-9e4a-e800413b7599.png">|<img width="80%" alt="2018-05-24 17 24 40" src="https://user-images.githubusercontent.com/25450416/40473551-6daf49e2-5f77-11e8-9d32-c95ec90b5efa.png">|

