### PR TITLE
登録画面の実装

### DIFF
--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -24,6 +24,13 @@ export interface LoginAsync {
   password: string;
 }
 
+const REGISTER = 'REGISTER';
+export interface RegisterAsync {
+  type: string;
+  username: string;
+  password: string;
+}
+
 const LOGOUT = 'LOGOUT';
 export interface Logout {
   type: string;
@@ -61,6 +68,17 @@ export function login(username: string, isAdmin: boolean): Login {
 export function loginAsync(username: string, password: string): LoginAsync {
   return {
     type: LOGIN_ASYNC,
+    username,
+    password,
+  };
+}
+
+export function registerAsync(
+  username: string,
+  password: string,
+): RegisterAsync {
+  return {
+    type: REGISTER,
     username,
     password,
   };

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -24,7 +24,7 @@ export interface LoginAsync {
   password: string;
 }
 
-const REGISTER = 'REGISTER';
+const REGISTER_ASYNC = 'REGISTER_ASYNC';
 export interface RegisterAsync {
   type: string;
   username: string;
@@ -78,7 +78,7 @@ export function registerAsync(
   password: string,
 ): RegisterAsync {
   return {
-    type: REGISTER,
+    type: REGISTER_ASYNC,
     username,
     password,
   };

--- a/src/api/AttendanceApi.ts
+++ b/src/api/AttendanceApi.ts
@@ -3,7 +3,24 @@ const headers = {
   'Content-Type': 'application/json',
 };
 
-// TODO: put postResister
+export function postRegister(name: string, password: string) {
+  return fetch(`${endPoint}/register`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      name,
+      password,
+    }),
+    mode: 'cors',
+  }).then(res => {
+    if (!res.ok) {
+      return res.json().then(data => {
+        throw new Error(data.message);
+      });
+    }
+    return res.json();
+  });
+}
 
 export function postLogin(name: string, password: string) {
   return fetch(`${endPoint}/login`, {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,6 +23,12 @@ const UserNavigation = (account: Account, logout: () => void) => {
         ログアウト
       </Link>
     </div>
+  ) : location.pathname === '/login' ? (
+    <div>
+      <Link to="/register" className="siimple-btn siimple-btn--green">
+        登録
+      </Link>
+    </div>
   ) : (
     <div>
       <Link to="/login" className="siimple-btn siimple-btn--blue">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,11 +25,7 @@ const UserNavigation = (account: Account, logout: () => void) => {
     </div>
   ) : (
     <div>
-      <Link
-        to="/login"
-        className="siimple-btn siimple-btn--blue"
-        style={{ margin: '4px', width: '80px' }}
-      >
+      <Link to="/login" className="siimple-btn siimple-btn--blue">
         ログイン
       </Link>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,9 +24,22 @@ const UserNavigation = (account: Account, logout: () => void) => {
       </Link>
     </div>
   ) : (
-    <Link to="/login" className="siimple-btn siimple-btn--blue">
-      ログイン
-    </Link>
+    <div>
+      <Link
+        to="/login"
+        className="siimple-btn siimple-btn--blue"
+        style={{ margin: '4px', width: '80px' }}
+      >
+        ログイン
+      </Link>
+      <Link
+        to="/register"
+        className="siimple-btn siimple-btn--green"
+        style={{ margin: '4px', width: '80px' }}
+      >
+        登録
+      </Link>
+    </div>
   );
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -32,13 +32,6 @@ const UserNavigation = (account: Account, logout: () => void) => {
       >
         ログイン
       </Link>
-      <Link
-        to="/"
-        className="siimple-btn siimple-btn--green"
-        style={{ margin: '4px', width: '80px' }}
-      >
-        登録
-      </Link>
     </div>
   );
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ const UserNavigation = (account: Account, logout: () => void) => {
         ログイン
       </Link>
       <Link
-        to="/register"
+        to="/"
         className="siimple-btn siimple-btn--green"
         style={{ margin: '4px', width: '80px' }}
       >

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -53,9 +53,9 @@ class RegisterForm extends React.Component<
     const rootLabel = location.pathname === '/' ? 'root-label' : '';
     return (
       <form className="siimple-form">
-        <div className={rootLabel + ' siimple-form-title'}>登録</div>
+        <div className={[rootLabel, ' siimple-form-title'].join(' ')}>登録</div>
         <div className="siimple-form-field">
-          <div className={rootLabel + ' siimple-form-field-label'}>
+          <div className={[rootLabel, ' siimple-form-field-label'].join(' ')}>
             ユーザー名
           </div>
           <input
@@ -67,7 +67,7 @@ class RegisterForm extends React.Component<
           />
         </div>
         <div className="siimple-form-field">
-          <div className={rootLabel + ' siimple-form-field-label'}>
+          <div className={[rootLabel, ' siimple-form-field-label'].join(' ')}>
             パスワード
           </div>
           <input
@@ -77,7 +77,7 @@ class RegisterForm extends React.Component<
             value={this.state.password}
             onChange={event => this.setState({ password: event.target.value })}
           />
-          <div className={rootLabel + ' siimple-field-helper'}>
+          <div className={[rootLabel, ' siimple-field-helper'].join(' ')}>
             英数字と記号のみ使用可能です
           </div>
           <input
@@ -89,7 +89,7 @@ class RegisterForm extends React.Component<
               this.setState({ passwordOnce: event.target.value })
             }
           />
-          <div className={rootLabel + ' siimple-field-helper'}>
+          <div className={[rootLabel, ' siimple-field-helper'].join(' ')}>
             もう一度パスワードを入力してください。
           </div>
         </div>

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -50,11 +50,14 @@ class RegisterForm extends React.Component<
 
   render() {
     const { error } = this.props;
+    const rootLabel = location.pathname === '/' ? 'root-label' : '';
     return (
-      <form className="siimple-form login-form">
-        <div className="siimple-form-title">登録</div>
+      <form className="siimple-form">
+        <div className={rootLabel + ' siimple-form-title'}>登録</div>
         <div className="siimple-form-field">
-          <div className="siimple-form-field-label">ユーザー名</div>
+          <div className={rootLabel + ' siimple-form-field-label'}>
+            ユーザー名
+          </div>
           <input
             type="text"
             className="siimple-input siimple-input--fluid"
@@ -64,7 +67,9 @@ class RegisterForm extends React.Component<
           />
         </div>
         <div className="siimple-form-field">
-          <div className="siimple-form-field-label">パスワード</div>
+          <div className={rootLabel + ' siimple-form-field-label'}>
+            パスワード
+          </div>
           <input
             type="password"
             className="siimple-input siimple-input--fluid"
@@ -72,7 +77,7 @@ class RegisterForm extends React.Component<
             value={this.state.password}
             onChange={event => this.setState({ password: event.target.value })}
           />
-          <div className="siimple-field-helper">
+          <div className={rootLabel + ' siimple-field-helper'}>
             英数字と記号のみ使用可能です
           </div>
           <input
@@ -84,7 +89,7 @@ class RegisterForm extends React.Component<
               this.setState({ passwordOnce: event.target.value })
             }
           />
-          <div className="siimple-field-helper">
+          <div className={rootLabel + ' siimple-field-helper'}>
             もう一度パスワードを入力してください。
           </div>
         </div>
@@ -105,7 +110,7 @@ class RegisterForm extends React.Component<
           </button>
         </div>
         {error.isError && (
-          <div className="siimple-form-field-helper siimple--color-red">
+          <div className="siimple-form-field-helper siimple--color-red-dark">
             {error.message}
           </div>
         )}

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import Error from '../models/Error';
+
+interface RegisterFormProperties {
+  error: Error;
+  register(name: string, password: string): void;
+  handleError(isError: boolean, message: string): void;
+}
+
+interface RegisterFormState {
+  name: string;
+  password: string;
+  passwordOnce: string;
+}
+
+class RegisterForm extends React.Component<
+  RegisterFormProperties,
+  RegisterFormState
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      name: '',
+      password: '',
+      passwordOnce: '',
+    };
+    this.handleRegister = this.handleRegister.bind(this);
+  }
+
+  handleRegister(
+    event: React.FormEvent<HTMLElement>,
+    name: string,
+    password: string,
+    passwordOnce: string,
+  ) {
+    const { register, handleError } = this.props;
+    if (name === '' || password === '' || passwordOnce === '') {
+      return;
+    }
+    if (password !== passwordOnce) {
+      event.preventDefault();
+      handleError(true, '異なるパスワードを入力しています');
+      this.setState({ password: '', passwordOnce: '' });
+      return;
+    }
+    handleError(false, '');
+    register(name, password);
+    event.preventDefault();
+  }
+
+  render() {
+    const { error } = this.props;
+    return (
+      <form className="siimple-form login-form">
+        <div className="siimple-form-title">登録</div>
+        <div className="siimple-form-field">
+          <div className="siimple-form-field-label">ユーザー名</div>
+          <input
+            type="text"
+            className="siimple-input siimple-input--fluid"
+            required
+            value={this.state.name}
+            onChange={event => this.setState({ name: event.target.value })}
+          />
+        </div>
+        <div className="siimple-form-field">
+          <div className="siimple-form-field-label">パスワード</div>
+          <input
+            type="password"
+            className="siimple-input siimple-input--fluid"
+            required
+            value={this.state.password}
+            onChange={event => this.setState({ password: event.target.value })}
+          />
+          <div className="siimple-field-helper">
+            英数字と記号のみ使用可能です
+          </div>
+          <input
+            type="password"
+            className="siimple-input siimple-input--fluid"
+            required
+            value={this.state.passwordOnce}
+            onChange={event =>
+              this.setState({ passwordOnce: event.target.value })
+            }
+          />
+          <div className="siimple-field-helper">
+            もう一度パスワードを入力してください。
+          </div>
+        </div>
+        <div className="siimple-form-field">
+          <button
+            className="siimple-btn siimple-btn--green"
+            type="submit"
+            onClick={event =>
+              this.handleRegister(
+                event,
+                this.state.name,
+                this.state.password,
+                this.state.passwordOnce,
+              )
+            }
+          >
+            登録
+          </button>
+        </div>
+        {error.isError && (
+          <div className="siimple-form-field-helper siimple--color-red">
+            {error.message}
+          </div>
+        )}
+      </form>
+    );
+  }
+}
+
+export default RegisterForm;

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -8,6 +8,7 @@ interface LoginProperties {
   login(id: string, password: string): void;
   account: Account;
   error: Error;
+  refreshError(): void;
 }
 
 interface LoginState {
@@ -25,21 +26,27 @@ class Login extends React.Component<LoginProperties, LoginState> {
     this.handleLogin = this.handleLogin.bind(this);
   }
 
+  componentWillMount() {
+    const { refreshError } = this.props;
+    refreshError();
+  }
+
   handleLogin(
     event: React.FormEvent<HTMLElement>,
     name: string,
     password: string,
   ) {
-    const { login } = this.props;
+    const { login, refreshError } = this.props;
     if (name === '' || password === '') {
       return;
     }
+    refreshError();
     login(name, password);
     event.preventDefault();
   }
 
   render() {
-    const { login, account, error } = this.props;
+    const { account, error } = this.props;
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -50,47 +50,51 @@ class Login extends React.Component<LoginProperties, LoginState> {
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (
-      <form className="siimple-form login-form">
-        <div className="siimple-form-title">ログイン</div>
-        <div className="siimple-form-field">
-          <div className="siimple-form-field-label">ユーザー名</div>
-          <input
-            type="text"
-            className="siimple-input siimple-input--fluid"
-            placeholder="kiesproject"
-            required
-            value={this.state.name}
-            onChange={event => this.setState({ name: event.target.value })}
-          />
-        </div>
-        <div className="siimple-form-field">
-          <div className="siimple-form-field-label">パスワード</div>
-          <input
-            type="password"
-            className="siimple-input siimple-input--fluid"
-            placeholder="*********"
-            required
-            value={this.state.password}
-            onChange={event => this.setState({ password: event.target.value })}
-          />
-        </div>
-        <div className="siimple-form-field">
-          <button
-            className="siimple-btn siimple-btn--blue"
-            type="submit"
-            onClick={event =>
-              this.handleLogin(event, this.state.name, this.state.password)
-            }
-          >
-            ログイン
-          </button>
-        </div>
-        {error.isError && (
-          <div className="siimple-form-field-helper siimple--color-red">
-            {error.message}
+      <div className="login-form">
+        <form className="siimple-form">
+          <div className="siimple-form-title">ログイン</div>
+          <div className="siimple-form-field">
+            <div className="siimple-form-field-label">ユーザー名</div>
+            <input
+              type="text"
+              className="siimple-input siimple-input--fluid"
+              placeholder="kiesproject"
+              required
+              value={this.state.name}
+              onChange={event => this.setState({ name: event.target.value })}
+            />
           </div>
-        )}
-      </form>
+          <div className="siimple-form-field">
+            <div className="siimple-form-field-label">パスワード</div>
+            <input
+              type="password"
+              className="siimple-input siimple-input--fluid"
+              placeholder="*********"
+              required
+              value={this.state.password}
+              onChange={event =>
+                this.setState({ password: event.target.value })
+              }
+            />
+          </div>
+          <div className="siimple-form-field">
+            <button
+              className="siimple-btn siimple-btn--blue"
+              type="submit"
+              onClick={event =>
+                this.handleLogin(event, this.state.name, this.state.password)
+              }
+            >
+              ログイン
+            </button>
+          </div>
+          {error.isError && (
+            <div className="siimple-form-field-helper siimple--color-red">
+              {error.message}
+            </div>
+          )}
+        </form>
+      </div>
     );
   }
 }

--- a/src/components/screens/Login.tsx
+++ b/src/components/screens/Login.tsx
@@ -8,7 +8,7 @@ interface LoginProperties {
   login(id: string, password: string): void;
   account: Account;
   error: Error;
-  refreshError(): void;
+  handleError(isError: boolean, message: ''): void;
 }
 
 interface LoginState {
@@ -27,8 +27,8 @@ class Login extends React.Component<LoginProperties, LoginState> {
   }
 
   componentWillMount() {
-    const { refreshError } = this.props;
-    refreshError();
+    const { handleError } = this.props;
+    handleError(false, '');
   }
 
   handleLogin(
@@ -36,11 +36,11 @@ class Login extends React.Component<LoginProperties, LoginState> {
     name: string,
     password: string,
   ) {
-    const { login, refreshError } = this.props;
+    const { login, handleError } = this.props;
     if (name === '' || password === '') {
       return;
     }
-    refreshError();
+    handleError(false, '');
     login(name, password);
     event.preventDefault();
   }

--- a/src/components/screens/Register.tsx
+++ b/src/components/screens/Register.tsx
@@ -38,12 +38,14 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
     passwordOnce: string,
   ) {
     const { handleError } = this.props;
-    if (name === '' || password === '') {
+    if (name === '' || password === '' || passwordOnce === '') {
       return;
     }
     if (password !== passwordOnce) {
       event.preventDefault();
-      return handleError(true, '異なるパスワードを入力しています');
+      handleError(true, '異なるパスワードを入力しています');
+      this.setState({ password: '', passwordOnce: '' });
+      return;
     }
     handleError(false, '');
     // TODO: dispatch register

--- a/src/components/screens/Register.tsx
+++ b/src/components/screens/Register.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+import Account from '../../models/Account';
+import Error from '../../models/Error';
+
+interface RegisterProperties {
+  account: Account;
+  error: Error;
+  refreshError(): void;
+}
+
+interface RegisterState {
+  name: string;
+  password: string;
+}
+
+class Register extends React.Component<RegisterProperties, RegisterState> {
+  constructor(props: RegisterProperties) {
+    super(props);
+    this.state = {
+      name: '',
+      password: '',
+    };
+    this.handleRegister = this.handleRegister.bind(this);
+  }
+
+  componentWillMount() {
+    const { refreshError } = this.props;
+    refreshError();
+  }
+
+  handleRegister(
+    event: React.FormEvent<HTMLElement>,
+    name: string,
+    password: string,
+  ) {
+    console.log('handleRegister', name, password);
+  }
+
+  render() {
+    const { account, error } = this.props;
+    return account.loggedIn ? (
+      <Redirect to="/home" />
+    ) : (
+      <form className="siimple-form login-form">
+        <div className="siimple-form-title">登録</div>
+        <div className="siimple-form-field">
+          <div className="siimple-form-field-label">ユーザー名</div>
+          <input
+            type="text"
+            className="siimple-input siimple-input--fluid"
+            placeholder="kiesproject"
+            required
+            value={this.state.name}
+            onChange={event => this.setState({ name: event.target.value })}
+          />
+        </div>
+        <div className="siimple-form-field">
+          <div className="siimple-form-field-label">パスワード</div>
+          <input
+            type="password"
+            className="siimple-input siimple-input--fluid"
+            required
+            value={this.state.password}
+            onChange={event => this.setState({ password: event.target.value })}
+          />
+        </div>
+        <div className="siimple-form-field">
+          <button
+            className="siimple-btn siimple-btn--blue"
+            type="submit"
+            onClick={event =>
+              this.handleRegister(event, this.state.name, this.state.password)
+            }
+          >
+            登録
+          </button>
+        </div>
+        {error.isError && (
+          <div className="siimple-form-field-helper siimple--color-red">
+            {error.message}
+          </div>
+        )}
+      </form>
+    );
+  }
+}
+
+export default Register;

--- a/src/components/screens/Register.tsx
+++ b/src/components/screens/Register.tsx
@@ -6,12 +6,13 @@ import Error from '../../models/Error';
 interface RegisterProperties {
   account: Account;
   error: Error;
-  refreshError(): void;
+  handleError(isError: boolean, message: string): void;
 }
 
 interface RegisterState {
   name: string;
   password: string;
+  passwordOnce: string;
 }
 
 class Register extends React.Component<RegisterProperties, RegisterState> {
@@ -20,21 +21,34 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
     this.state = {
       name: '',
       password: '',
+      passwordOnce: '',
     };
     this.handleRegister = this.handleRegister.bind(this);
   }
 
   componentWillMount() {
-    const { refreshError } = this.props;
-    refreshError();
+    const { handleError } = this.props;
+    handleError(false, '');
   }
 
   handleRegister(
     event: React.FormEvent<HTMLElement>,
     name: string,
     password: string,
+    passwordOnce: string,
   ) {
-    console.log('handleRegister', name, password);
+    const { handleError } = this.props;
+    if (name === '' || password === '') {
+      return;
+    }
+    if (password !== passwordOnce) {
+      event.preventDefault();
+      return handleError(true, '異なるパスワードを入力しています');
+    }
+    handleError(false, '');
+    // TODO: dispatch register
+
+    event.preventDefault();
   }
 
   render() {
@@ -49,7 +63,6 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
           <input
             type="text"
             className="siimple-input siimple-input--fluid"
-            placeholder="kiesproject"
             required
             value={this.state.name}
             onChange={event => this.setState({ name: event.target.value })}
@@ -64,13 +77,33 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
             value={this.state.password}
             onChange={event => this.setState({ password: event.target.value })}
           />
+          <div className="siimple-field-helper">
+            英数字と記号のみ使用可能です
+          </div>
+          <input
+            type="password"
+            className="siimple-input siimple-input--fluid"
+            required
+            value={this.state.passwordOnce}
+            onChange={event =>
+              this.setState({ passwordOnce: event.target.value })
+            }
+          />
+          <div className="siimple-field-helper">
+            もう一度パスワードを入力してください。
+          </div>
         </div>
         <div className="siimple-form-field">
           <button
-            className="siimple-btn siimple-btn--blue"
+            className="siimple-btn siimple-btn--green"
             type="submit"
             onClick={event =>
-              this.handleRegister(event, this.state.name, this.state.password)
+              this.handleRegister(
+                event,
+                this.state.name,
+                this.state.password,
+                this.state.passwordOnce,
+              )
             }
           >
             登録

--- a/src/components/screens/Register.tsx
+++ b/src/components/screens/Register.tsx
@@ -6,6 +6,7 @@ import Error from '../../models/Error';
 interface RegisterProperties {
   account: Account;
   error: Error;
+  register(name: string, password: string): void;
   handleError(isError: boolean, message: string): void;
 }
 
@@ -37,7 +38,7 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
     password: string,
     passwordOnce: string,
   ) {
-    const { handleError } = this.props;
+    const { register, handleError } = this.props;
     if (name === '' || password === '' || passwordOnce === '') {
       return;
     }
@@ -48,8 +49,7 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
       return;
     }
     handleError(false, '');
-    // TODO: dispatch register
-
+    register(name, password);
     event.preventDefault();
   }
 

--- a/src/components/screens/Root.tsx
+++ b/src/components/screens/Root.tsx
@@ -19,11 +19,23 @@ class Root extends React.Component<RegisterProperties, any> {
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (
-      <RegisterForm
-        error={error}
-        register={register}
-        handleError={handleError}
-      />
+      <div className="root">
+        <div className="welcome-title">
+          <div className="siimple-h1 siimple--color-white">
+            ようこそサボらん♨へ︎
+          </div>
+          <div className="siimple-p siimple--color-white">
+            登録はこのページのフォームから！ログインは右上のボタンから！
+          </div>
+        </div>
+        <div className="welcome-form">
+          <RegisterForm
+            error={error}
+            register={register}
+            handleError={handleError}
+          />
+        </div>
+      </div>
     );
   }
 }

--- a/src/components/screens/Root.tsx
+++ b/src/components/screens/Root.tsx
@@ -23,7 +23,7 @@ class Root extends React.Component<RegisterProperties, any> {
         <div className="root-inner">
           <div className="welcome-title">
             <div className="siimple-jumbotron-title siimple--color-white">
-              ようこそXXXXXへ︎
+              ようこそサボらん♨︎へ︎
             </div>
             <div className="siimple-jumbotron-detail siimple--color-white">
               登録はこのページのフォームから！ログインは右上のボタンから！

--- a/src/components/screens/Root.tsx
+++ b/src/components/screens/Root.tsx
@@ -20,20 +20,22 @@ class Root extends React.Component<RegisterProperties, any> {
       <Redirect to="/home" />
     ) : (
       <div className="root">
-        <div className="welcome-title">
-          <div className="siimple-h1 siimple--color-white">
-            ようこそサボらん♨へ︎
+        <div className="root-inner">
+          <div className="welcome-title">
+            <div className="siimple-jumbotron-title siimple--color-white">
+              ようこそXXXXXへ︎
+            </div>
+            <div className="siimple-jumbotron-detail siimple--color-white">
+              登録はこのページのフォームから！ログインは右上のボタンから！
+            </div>
           </div>
-          <div className="siimple-p siimple--color-white">
-            登録はこのページのフォームから！ログインは右上のボタンから！
+          <div className="welcome-form">
+            <RegisterForm
+              error={error}
+              register={register}
+              handleError={handleError}
+            />
           </div>
-        </div>
-        <div className="welcome-form">
-          <RegisterForm
-            error={error}
-            register={register}
-            handleError={handleError}
-          />
         </div>
       </div>
     );

--- a/src/components/screens/Root.tsx
+++ b/src/components/screens/Root.tsx
@@ -16,7 +16,7 @@ interface RegisterState {
   passwordOnce: string;
 }
 
-class Register extends React.Component<RegisterProperties, RegisterState> {
+class Root extends React.Component<RegisterProperties, RegisterState> {
   constructor(props: RegisterProperties) {
     super(props);
     this.state = {
@@ -121,4 +121,4 @@ class Register extends React.Component<RegisterProperties, RegisterState> {
   }
 }
 
-export default Register;
+export default Root;

--- a/src/components/screens/Root.tsx
+++ b/src/components/screens/Root.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { Redirect } from 'react-router-dom';
+
+import RegisterForm from '../RegisterForm';
+
 import Account from '../../models/Account';
 import Error from '../../models/Error';
 
@@ -10,113 +13,17 @@ interface RegisterProperties {
   handleError(isError: boolean, message: string): void;
 }
 
-interface RegisterState {
-  name: string;
-  password: string;
-  passwordOnce: string;
-}
-
-class Root extends React.Component<RegisterProperties, RegisterState> {
-  constructor(props: RegisterProperties) {
-    super(props);
-    this.state = {
-      name: '',
-      password: '',
-      passwordOnce: '',
-    };
-    this.handleRegister = this.handleRegister.bind(this);
-  }
-
-  componentWillMount() {
-    const { handleError } = this.props;
-    handleError(false, '');
-  }
-
-  handleRegister(
-    event: React.FormEvent<HTMLElement>,
-    name: string,
-    password: string,
-    passwordOnce: string,
-  ) {
-    const { register, handleError } = this.props;
-    if (name === '' || password === '' || passwordOnce === '') {
-      return;
-    }
-    if (password !== passwordOnce) {
-      event.preventDefault();
-      handleError(true, '異なるパスワードを入力しています');
-      this.setState({ password: '', passwordOnce: '' });
-      return;
-    }
-    handleError(false, '');
-    register(name, password);
-    event.preventDefault();
-  }
-
+class Root extends React.Component<RegisterProperties, any> {
   render() {
-    const { account, error } = this.props;
+    const { account, error, register, handleError } = this.props;
     return account.loggedIn ? (
       <Redirect to="/home" />
     ) : (
-      <form className="siimple-form login-form">
-        <div className="siimple-form-title">登録</div>
-        <div className="siimple-form-field">
-          <div className="siimple-form-field-label">ユーザー名</div>
-          <input
-            type="text"
-            className="siimple-input siimple-input--fluid"
-            required
-            value={this.state.name}
-            onChange={event => this.setState({ name: event.target.value })}
-          />
-        </div>
-        <div className="siimple-form-field">
-          <div className="siimple-form-field-label">パスワード</div>
-          <input
-            type="password"
-            className="siimple-input siimple-input--fluid"
-            required
-            value={this.state.password}
-            onChange={event => this.setState({ password: event.target.value })}
-          />
-          <div className="siimple-field-helper">
-            英数字と記号のみ使用可能です
-          </div>
-          <input
-            type="password"
-            className="siimple-input siimple-input--fluid"
-            required
-            value={this.state.passwordOnce}
-            onChange={event =>
-              this.setState({ passwordOnce: event.target.value })
-            }
-          />
-          <div className="siimple-field-helper">
-            もう一度パスワードを入力してください。
-          </div>
-        </div>
-        <div className="siimple-form-field">
-          <button
-            className="siimple-btn siimple-btn--green"
-            type="submit"
-            onClick={event =>
-              this.handleRegister(
-                event,
-                this.state.name,
-                this.state.password,
-                this.state.passwordOnce,
-              )
-            }
-          >
-            登録
-          </button>
-        </div>
-        {error.isError && (
-          <div className="siimple-form-field-helper siimple--color-red">
-            {error.message}
-          </div>
-        )}
-      </form>
+      <RegisterForm
+        error={error}
+        register={register}
+        handleError={handleError}
+      />
     );
   }
 }

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -88,11 +88,13 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
             <Route
               path="/register"
               render={() => (
-                <RegisterForm
-                  error={error}
-                  register={this.register}
-                  handleError={this.handleError}
-                />
+                <div className="register-form">
+                  <RegisterForm
+                    error={error}
+                    register={this.register}
+                    handleError={this.handleError}
+                  />
+                </div>
               )}
             />
             <Route

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -24,6 +24,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
     this.increase = this.increase.bind(this);
     this.decrease = this.decrease.bind(this);
     this.login = this.login.bind(this);
+    this.register = this.register.bind(this);
     this.logout = this.logout.bind(this);
     this.handleError = this.handleError.bind(this);
   }
@@ -41,6 +42,11 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
   login(id: string, password: string): void {
     const { dispatch } = this.props;
     dispatch(loginAsync(id, password));
+  }
+
+  register(name: string, password: string): void {
+    const { dispatch } = this.props;
+    dispatch(loginAsync(name, password));
   }
 
   logout(): void {
@@ -75,6 +81,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
               path="/register"
               render={() => (
                 <Register
+                  register={this.register}
                   account={account}
                   error={error}
                   handleError={this.handleError}

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -15,6 +15,7 @@ import {
   registerAsync,
 } from '../action';
 import Navbar from '../components/Navbar';
+import RegisterForm from '../components/RegisterForm';
 import Account from '../models/Account';
 import Error from '../models/Error';
 
@@ -80,6 +81,16 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
                   login={this.login}
                   account={account}
                   error={error}
+                  handleError={this.handleError}
+                />
+              )}
+            />
+            <Route
+              path="/register"
+              render={() => (
+                <RegisterForm
+                  error={error}
+                  register={this.register}
                   handleError={this.handleError}
                 />
               )}

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -6,7 +6,14 @@ import Home from '../components/screens/Home';
 import Login from '../components/screens/Login';
 import Register from '../components/screens/Register';
 
-import { decrease, error, increase, loginAsync, logout } from '../action';
+import {
+  decrease,
+  error,
+  increase,
+  loginAsync,
+  logout,
+  registerAsync,
+} from '../action';
 import Navbar from '../components/Navbar';
 import Account from '../models/Account';
 import Error from '../models/Error';
@@ -46,7 +53,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
 
   register(name: string, password: string): void {
     const { dispatch } = this.props;
-    dispatch(loginAsync(name, password));
+    dispatch(registerAsync(name, password));
   }
 
   logout(): void {

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -25,7 +25,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
     this.decrease = this.decrease.bind(this);
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
-    this.refreshError = this.refreshError.bind(this);
+    this.handleError = this.handleError.bind(this);
   }
 
   increase(count: number): void {
@@ -48,9 +48,9 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
     dispatch(logout());
   }
 
-  refreshError(): void {
+  handleError(isError: boolean, message: string): void {
     const { dispatch } = this.props;
-    dispatch(error(false, ''));
+    dispatch(error(isError, message));
   }
 
   render() {
@@ -67,7 +67,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
                   login={this.login}
                   account={account}
                   error={error}
-                  refreshError={this.refreshError}
+                  handleError={this.handleError}
                 />
               )}
             />
@@ -77,7 +77,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
                 <Register
                   account={account}
                   error={error}
-                  refreshError={this.refreshError}
+                  handleError={this.handleError}
                 />
               )}
             />

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -4,8 +4,9 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import Home from '../components/screens/Home';
 import Login from '../components/screens/Login';
+import Register from '../components/screens/Register';
 
-import { decrease, increase, loginAsync, logout } from '../action';
+import { decrease, error, increase, loginAsync, logout } from '../action';
 import Navbar from '../components/Navbar';
 import Account from '../models/Account';
 import Error from '../models/Error';
@@ -24,6 +25,7 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
     this.decrease = this.decrease.bind(this);
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
+    this.refreshError = this.refreshError.bind(this);
   }
 
   increase(count: number): void {
@@ -46,6 +48,11 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
     dispatch(logout());
   }
 
+  refreshError(): void {
+    const { dispatch } = this.props;
+    dispatch(error(false, ''));
+  }
+
   render() {
     const { number, account, error } = this.props;
     return (
@@ -56,7 +63,22 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
             <Route
               path="/login"
               render={() => (
-                <Login login={this.login} account={account} error={error} />
+                <Login
+                  login={this.login}
+                  account={account}
+                  error={error}
+                  refreshError={this.refreshError}
+                />
+              )}
+            />
+            <Route
+              path="/register"
+              render={() => (
+                <Register
+                  account={account}
+                  error={error}
+                  refreshError={this.refreshError}
+                />
               )}
             />
             <Route

--- a/src/container/AppContainer.tsx
+++ b/src/container/AppContainer.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 
 import Home from '../components/screens/Home';
 import Login from '../components/screens/Login';
-import Register from '../components/screens/Register';
+import Root from '../components/screens/Root';
 
 import {
   decrease,
@@ -85,17 +85,6 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
               )}
             />
             <Route
-              path="/register"
-              render={() => (
-                <Register
-                  register={this.register}
-                  account={account}
-                  error={error}
-                  handleError={this.handleError}
-                />
-              )}
-            />
-            <Route
               path="/home"
               render={() => (
                 <Home
@@ -106,6 +95,18 @@ class AppContainer extends React.Component<AppContainerProperties, any> {
                 />
               )}
             />
+            <Route
+              path="/"
+              render={() => (
+                <Root
+                  register={this.register}
+                  account={account}
+                  error={error}
+                  handleError={this.handleError}
+                />
+              )}
+            />
+            <Redirect from="*" to="/" />
           </Switch>
         </div>
       </BrowserRouter>

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -14,10 +14,19 @@ function* loginAsync(action: LoginAsync) {
   }
 }
 
+function* registerAsync(action: any) {
+  const { username: name, password } = action;
+  yield console.log('registerAsync', name, password);
+}
+
 function* watchLogin() {
   yield takeEvery('LOGIN_ASYNC', loginAsync);
 }
 
+function* watchRegister() {
+  yield takeEvery('REGISTER_ASYNC', registerAsync);
+}
+
 export default function* rootSaga() {
-  yield all([watchLogin()]);
+  yield all([watchLogin(), watchRegister()]);
 }

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -1,13 +1,14 @@
 import { all, call, put, takeEvery } from 'redux-saga/effects';
 
 import { error as errorAction, login, LoginAsync } from '../action/';
-import { postLogin } from '../api/AttendanceApi';
+import { postLogin, postRegister } from '../api/AttendanceApi';
 
 function* loginAsync(action: LoginAsync) {
   const { username: name, password } = action;
   try {
     const response = yield call(postLogin, name, password);
     // TODO: get administer authority by response
+    // TODO: レスポンスは今後変わるかも？
     yield put(login(response.user, true));
   } catch (error) {
     yield put(errorAction(true, error.message));
@@ -16,7 +17,13 @@ function* loginAsync(action: LoginAsync) {
 
 function* registerAsync(action: any) {
   const { username: name, password } = action;
-  yield console.log('registerAsync', name, password);
+  try {
+    yield call(postRegister, name, password);
+    // TODO: レスポンスは今後変わるかも？
+    yield put(login(name, false));
+  } catch (error) {
+    yield put(errorAction(true, error.message));
+  }
 }
 
 function* watchLogin() {

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -9,9 +9,7 @@ function* loginAsync(action: LoginAsync) {
     const response = yield call(postLogin, name, password);
     // TODO: get administer authority by response
     yield put(login(response.user, true));
-    yield put(errorAction(false, ''));
   } catch (error) {
-    // TODO: put action to error
     yield put(errorAction(true, error.message));
   }
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -20,4 +20,6 @@ html, body {
   }
 }
 
+@import "root";
 @import "login";
+@import "register";

--- a/src/scss/login.scss
+++ b/src/scss/login.scss
@@ -1,5 +1,6 @@
 .login-form {
   max-width: 20rem;
+  padding: 2rem;
   margin: auto;
   padding-top: 5rem;
 }

--- a/src/scss/register.scss
+++ b/src/scss/register.scss
@@ -1,0 +1,5 @@
+.register-form {
+  max-width: 20rem;
+  margin: auto;
+  padding-top: 5rem;
+}

--- a/src/scss/register.scss
+++ b/src/scss/register.scss
@@ -1,5 +1,12 @@
 .register-form {
   max-width: 20rem;
+  padding: 2rem;
   margin: auto;
   padding-top: 5rem;
+}
+
+.register-form-inner {
+  margin: {
+    bottom: 2rem;
+  }
 }

--- a/src/scss/root.scss
+++ b/src/scss/root.scss
@@ -1,6 +1,20 @@
 .root {
   background: $siimple-orange;
   overflow: hidden;
+  margin: {
+    right: auto;
+    left: auto;
+  }
+}
+
+.root-inner {
+  max-width: 1100px;
+  margin: {
+    top: 0px;
+    bottom: 0px;
+    right: auto;
+    left: auto;
+  }
 }
 
 .welcome-title {
@@ -12,10 +26,14 @@
 
 .welcome-form {
   float: right;
-  max-width: 20rem;
-  margin-top: 2rem;
-  margin-left: 2rem;
-  margin-right: 5rem;
+  min-width: 16rem;
+  max-width: 30rem;
+  padding: {
+    top: 2rem;
+    left: 2rem;
+    right: 2rem;
+    bottom: 0px;
+  }
 }
 
 .root-label {

--- a/src/scss/root.scss
+++ b/src/scss/root.scss
@@ -1,0 +1,23 @@
+.root {
+  background: $siimple-orange;
+  overflow: hidden;
+}
+
+.welcome-title {
+  float: left;
+  margin-top: 4rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.welcome-form {
+  float: right;
+  max-width: 20rem;
+  margin-top: 2rem;
+  margin-left: 2rem;
+  margin-right: 5rem;
+}
+
+.root-label {
+  color: $siimple-white;
+}


### PR DESCRIPTION
## issue
- close #9 

## がいよう
- ユーザー登録画面の作成〜ビジネスロジックの実装まで行いました
- 登録画面ではユーザー名とパスワードに加えてもう一度入力してもらう用のフォームも作成しました
- ユーザー名が被って登録失敗するとレスポンスのエラーメッセージがそのまんま表示されます

## スクショ
<img src=https://user-images.githubusercontent.com/25450416/40609348-56659f54-62a9-11e8-9b3a-e9405df385b5.png width="80%" />
